### PR TITLE
Add ability to pass db read preference through MONGO_URI

### DIFF
--- a/lib/core/mount.js
+++ b/lib/core/mount.js
@@ -50,6 +50,7 @@ var _ = require('underscore');
 var debug = require('debug')('keystone:core:mount');
 var P = require('bluebird');
 var express = require('express');
+var url = require('url');
 var path = require('path');
 var utils = require('keystone-utils');
 var favicon = require('serve-favicon');
@@ -568,7 +569,14 @@ function mount(mountPath, parentApp, events) {
 
 	} else {
 		debug('connecting to mongo');
+
+		var parsedMongoUri = url.parse(this.get('mongo'), true);
+		parsedMongoUri.query = parsedMongoUri.query || {};
+
 		var mongoOptions = {
+			db: {
+				readPreference: parsedMongoUri.query.readPreference
+			},
 			// This block gets run for a non replica set connection string (eg. localhost with a single DB)
 			server: {
 				poolSize: 5,


### PR DESCRIPTION
## Description of changes

There are 2 ways to pass replica set options:

  1. Using "mongo replica set" options
  2. Using MONGO_URI

When using MONGO_URI, readPreference query parameter is ignored. Thus there is no way to tell mongoose/mongodb the read preference.

## Related issues (if any)

none

## Testing

These appeared, just like the original "cermati" branch

```
  1) Keystone.session keystone.session.signin() case-insensitive email lookup shoud match email with mixed case:
     Uncaught TypeError: Cannot read property 'session' of null
      at lib/session.js:69:24
      at node_modules/grappling-hook/index.js:198:10

  2) Keystone.session keystone.session.signin() case-insensitive email lookup shoud match email with all uppercase:
     Uncaught TypeError: Cannot read property 'session' of null
      at lib/session.js:69:24
      at node_modules/grappling-hook/index.js:198:10

  3) Keystone.session keystone.session.signin() case-insensitive email lookup shoud match email with all lowercase:
     Uncaught TypeError: Cannot read property 'session' of null
      at lib/session.js:69:24
      at node_modules/grappling-hook/index.js:198:10

```