### PR TITLE
Upgrade mongoose to v4.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "marked": "^0.3.5",
     "method-override": "^2.3.5",
     "moment": "^2.10.6",
-    "mongoose": "~4.1.11",
+    "mongoose": "~4.10.8",
     "morgan": "^1.6.1",
     "mpromise": "^0.5.5",
     "multer": "^0.1.8",


### PR DESCRIPTION
## Description of changes
Upgrade mongoose to v4.10.8 in preparation on upgrading MongoDB to 3.4. Version 4.10 is used instead of v4.11 because it deprecate some methods used to connect to MongoDB and I'm not very sure how to fix it.

## Issues
**Do not** merge this PR unless the [diff for rajamoney](https://p.cermati.com/D5988) is already merged. This commit will break exsisting installation if `npm install`-ed, resulting in failed unit test using `npm test`.
